### PR TITLE
Use pdftocairo from Poppler_jll instead of pdf2svg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ sudo: required
 dist: trusty
 coveralls: true
 julia:
-  - 1.0
   - 1.3
   - 1.4
 notifications:
   email: false
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y pdf2svg
   - sudo apt-get install -y texlive-latex-base
   - sudo apt-get install -y texlive-binaries
   - sudo apt-get install -y texlive-pictures

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "3.1.0"
 
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -13,5 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["Test"]
 
 [compat]
-julia = "1.0"
+julia = "1.3"
 LaTeXStrings = "1.1"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ This library allows one to create Tikz pictures and save in various formats. It 
 
 In order to use this library, lualatex must be installed. The texlive and miktex distributions include lualatex. You must also have dvisvgm installed. On Ubuntu, you can get these, if not already present, by running `sudo apt-get install texlive-latex-base` and `sudo apt-get install texlive-binaries`.
 
-You also need pdf2svg. On Ubuntu, you can get this by running `sudo apt-get install pdf2svg`. On Windows, you can download the binaries from http://www.cityinthesky.co.uk/opensource/pdf2svg/. Be sure to add pdf2svg to your path (and restart).
-
 Note: this package will attempt to turn off interpolation in the generated SVG, but this currently only works in Chrome.
 
 ## Example


### PR DESCRIPTION
[Poppler_jll.jl](https://github.com/JuliaBinaryWrappers/Poppler_jll.jl) provides `pdftocairo` binary which could be a replacement for `pdf2svg`.

A good is that users no longer need to have external `pdf2svg` installed manually. A caveat though is that jll requires Julia 1.3+.

Only tested on macOS for now. I believe it should work on Windows and Linux too.
