### PR TITLE
Optionally omit the tikzpicture and document environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ tp = TikzPicture(L"""
 \node at (5,5) {tikz $\sqrt{\pi}$};"""
 , options="scale=0.25", preamble="")
 ```
+
+## Embedding TEX files in external documents
+
+Compiling a standalone LaTeX file requires the Tikz code to be wrapped in a `tikzpicture` environment, which again is wrapped in a `document` environment. You can omit these wrappers if you intend to embed the output in a larger document, instead of compiling it as a standalone file.
+
+```julia
+save(TEX("test"; limit_to=:all), tp) # the default, save a complete file
+save(TEX("test"; limit_to=:picture), tp) # only wrap in a tikzpicture environment
+save(TEX("test"; limit_to=:data), tp) # do not wrap the Tikz code, at all
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,13 +9,46 @@ for file in ["testPic.pdf", "testPic.svg", "testDoc.pdf", "testDoc.tex"]
 end
 
 # Run tests
-tp = TikzPicture("\\draw (0,0) -- (10,10);\n\\draw (10,0) -- (0,10);\n\\node at (5,5) {tikz \$\\sqrt{\\pi}\$};", options="scale=0.25", preamble="")
+data = "\\draw (0,0) -- (10,10);\n\\draw (10,0) -- (0,10);\n\\node at (5,5) {tikz \$\\sqrt{\\pi}\$};"
+tp = TikzPicture(data, options="scale=0.25", preamble="")
 td = TikzDocument()
 push!(td, tp, caption="hello")
 
 save(TEX("testPic"), tp)
 @test isfile("testPic.tex")
 
+# check that the TEX file contains the desired environments
+function has_environment(content::String, environment::String)
+    has_begin = occursin("\\begin{$environment}", content)
+    has_end = occursin("\\end{$environment}", content)
+    if has_begin && has_end
+        return true # has both
+    elseif !has_begin && !has_end
+        return false # has neither
+    else
+        error("\\begin{$environment} and \\end{$environment} do not match")
+    end
+end
+filecontent = join(readlines("testPic.tex", keep=true)) # read with line breaks
+@test occursin(data, filecontent) # also check that the data is contained
+@test has_environment(filecontent, "tikzpicture")
+@test has_environment(filecontent, "document")
+
+# same check for include_preamble=false and limit_to=:picture
+save(TEX("testPic"; include_preamble=false), tp)
+filecontent = join(readlines("testPic.tex", keep=true))
+@test occursin(data, filecontent)
+@test has_environment(filecontent, "tikzpicture") # must occur
+@test !has_environment(filecontent, "document") # must not occur
+
+# same check for limit_to=:data
+save(TEX("testPic"; limit_to=:data), tp)
+filecontent = join(readlines("testPic.tex", keep=true))
+@test occursin(data, filecontent)
+@test !has_environment(filecontent, "tikzpicture")
+@test !has_environment(filecontent, "document")
+
+save(TEX("testPic"), tp) # save again with limit_to=:all
 if success(`lualatex -v`)
 	save(PDF("testPic"), tp)
 	@test isfile("testPic.pdf")
@@ -25,6 +58,6 @@ if success(`lualatex -v`)
 
     save(PDF("testDoc"), td)
     @test isfile("testDoc.pdf")
+else
+    @warn "lualatex is missing; can not test compilation"
 end
-
-


### PR DESCRIPTION
I usually export my TikzPictures two times: once as a pdf/svg, which I use for immediate inspection; and then as a `TEX` file.

The latter one is always meant to be embedded in a larger document, which has its own preamble. Sometimes, I also want to omit the `tikzpicture` environment, so that setting `include_preamble=false` does not suffice. Skipping the `tikzpicture` environment has the advantage that  its options can be altered in the main document, without changing the included Tikz file.

Doing so is particularly nice when exporting Tikz code from [PGFPlots.jl](https://github.com/JuliaTeX/PGFPlots.jl).

This PR provides an option to either i) save a complete `TEX` file that can be compiled as a standalone document; ii) omit the preamble, which is just identical to setting `include_preamble=false`; and iii) to print the Tikz code just as it is. The first option remains the default and the `include_preamble` argument is maintained for compatibility.

```julia
save(TEX("test"; limit_to=:all), tp) # the default, save a complete file
save(TEX("test"; limit_to=:picture), tp) # only wrap in a tikzpicture environment
save(TEX("test"; include_preamble=false), tp) # equivalent to the above line
save(TEX("test"; limit_to=:data), tp) # do not wrap the Tikz code, at all
```

For those who do not use the new `limit_to` argument, nothing changes.