### PR TITLE
Provide multiple lazy-loaded backends for SVGs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,14 @@ sudo: required
 dist: trusty
 coveralls: true
 julia:
+  - 1.0
   - 1.3
   - 1.4
 notifications:
   email: false
 before_install:
   - sudo apt-get -qq update
+  - sudo apt-get install -y pdf2svg
   - sudo apt-get install -y texlive-latex-base
   - sudo apt-get install -y texlive-binaries
   - sudo apt-get install -y texlive-pictures

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ coveralls: true
 julia:
   - 1.0
   - 1.3
-  - 1.4
+  - 1.5
 notifications:
   email: false
 before_install:

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,14 @@ version = "3.2.0"
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[compat]
+LaTeXStrings = "1.1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-julia = "1.3"
-LaTeXStrings = "1.1"

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1,0 +1,102 @@
+using Requires
+export SVGBackend, PdfToSvgBackend, PopplerBackend, DVIBackend, svgBackend
+
+# types of backends that convert PDFs to SVGs
+abstract type SVGBackend end
+struct PdfToSvgBackend <: SVGBackend end
+struct PopplerBackend <: SVGBackend end
+struct DVIBackend <: SVGBackend end
+
+# the current backend with a getter and a setter
+const _svgBackend = Ref{SVGBackend}()
+
+svgBackend() = _svgBackend[]
+function svgBackend(backend::SVGBackend)
+    _initialize(backend)
+    _svgBackend[] = backend
+end
+
+# call this function from __init__
+function __init__svg()
+
+    # determine the backend to use
+    if Sys.which("pdf2svg") != nothing
+        svgBackend(PdfToSvgBackend())
+    else
+        svgBackend(PopplerBackend())
+    end
+
+    # define a new implementation for PopplerBackend, but only after `import Poppler_jll`
+    @require Poppler_jll="9c32591e-4766-534b-9725-b71a8799265b" begin
+        function _mkTempSvg(backend::PopplerBackend, tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString)
+            _mkTempPdf(tp, temp_dir, temp_filename) # convert to PDF and then to SVG
+            Poppler_jll.pdftocairo() do exe
+                return success(`$exe -svg $(temp_filename).pdf $(temp_filename).svg`)
+            end # convert PDF file in tmpdir to SVG file in tmpdir
+        end
+    end
+
+end
+
+#
+# This function is the one used by save(::SVG); produce an SVG file in the temporary directory
+#
+function _mkTempSvg(tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString)
+    backend = svgBackend()
+    if !_mkTempSvg(backend, tp, temp_dir, temp_filename)
+        if tikzDeleteIntermediate()
+            rm(temp_dir, force=true, recursive=true)
+        end
+        error("$backend failed. Consider using another backend.")
+    end # otherwise, everything is fine
+end
+
+# backend initialization
+_initialize(backend::SVGBackend) = nothing # default
+_initialize(backend::PopplerBackend) =
+    try
+        @eval Main begin
+            import Poppler_jll # will trigger @require in __init__svg
+        end
+    catch
+        error("Unable to initialize $backend") # should not happen as long as Poppler_jll is a dependency
+    end
+
+# compile a temporary PDF file that can be converted to SVG
+function _mkTempPdf(tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString; dvi::Bool=false)
+    latexArgs = String[tikzCommand()]
+    if tp.enableWrite18
+        push!(latexArgs, "--enable-write18")
+    end
+    if dvi
+        push!(latexArgs, "--output-format=dvi")
+    end
+    latexCommand = `$latexArgs --output-directory=$(temp_dir) $(temp_filename*".tex")`
+    latexSuccess = success(latexCommand)
+
+    tex_log = read(temp_filename * ".log", String)
+    if occursin("LaTeX Warning: Label(s)", tex_log)
+        latexSuccess = success(latexCommand)
+    end # second run
+
+    if !latexSuccess
+        latexerrormsg(tex_log)
+        error("LaTeX error")
+    end
+end
+
+# compile temporary SVGs with different backends
+_mkTempSvg(backend::SVGBackend, tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString) =
+    return false # always fail
+
+function _mkTempSvg(backend::PdfToSvgBackend, tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString)
+    _mkTempPdf(tp, temp_dir, temp_filename) # convert to PDF and then to SVG
+    return success(`pdf2svg $(temp_filename).pdf $(temp_filename).svg`)
+end
+
+function _mkTempSvg(backend::DVIBackend, tp::TikzPicture, temp_dir::AbstractString, temp_filename::AbstractString)
+    _mkTempPdf(tp, temp_dir, temp_filename; dvi=true) # convert to DVI and then to SVG
+    cd(temp_dir) do
+        return success(`dvisvgm --no-fonts --output=$(basename(temp_filename)*".svg") $(basename(temp_filename)*".dvi")`)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ svgBackends = [
     "testPic.poppler.svg" => PopplerBackend(),
     "testPic.dvisvgm.svg" => DVIBackend()
 ]
+if VERSION < v"1.3"
+    deleteat!(svgBackends, 2)
+    @warn "Not testing PopplerBackend on Julia versions < 1.3"
+end
 
 # Pre-test cleanup (for repeated tests)
 for file in ["testPic.pdf", "testPic.svg", "testDoc.pdf", "testDoc.tex", first.(svgBackends)...]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,14 @@
 using TikzPictures
 using Test
 
+svgBackends = [
+    "testPic.pdf2svg.svg" => PdfToSvgBackend(),
+    "testPic.poppler.svg" => PopplerBackend(),
+    "testPic.dvisvgm.svg" => DVIBackend()
+]
+
 # Pre-test cleanup (for repeated tests)
-for file in ["testPic.pdf", "testPic.svg", "testDoc.pdf", "testDoc.tex"]
+for file in ["testPic.pdf", "testPic.svg", "testDoc.pdf", "testDoc.tex", first.(svgBackends)...]
 	if isfile(file)
 		rm(file)
 	end
@@ -54,7 +60,13 @@ if success(`lualatex -v`)
 	@test isfile("testPic.pdf")
 
     save(SVG("testPic"), tp)
-    @test isfile("testPic.svg")
+    @test isfile("testPic.svg") # default SVG backend
+
+    @testset for (k, v) in svgBackends
+        svgBackend(v)
+        save(SVG(k), tp)
+        @test isfile(k)
+    end
 
     save(PDF("testDoc"), td)
     @test isfile("testDoc.pdf")


### PR DESCRIPTION
SVGs can now be produced with multiple backends:

- `Poppler_jll` lately was the default. It works on all platforms, but requires `julia-1.3` and is slow to load.
- `pdf2svg` was the former default. The user has to have this library installed.
- `dvisvgm` always was the fall-back solution if `tikzUsePoppler()` or `tikzusePDF2SVG()` was explicitly set to `false` by the user.

The original code for the `dvisvgm` fallback was somehow broken; I fixed it when implementing this PR.

Providing different backends has the advantage of (potentially) faster loading times that do not loose compatibility across platforms. We have already discussed the slow loading times and potential solutions: https://github.com/JuliaTeX/PGFPlots.jl/issues/130

`using TikzPictures` now checks whether `pdf2svg` is installed. If so, it uses the corresponding backend and the package loads quickly. If `pdf2svg` is not installed, the package uses `Poppler_jll` instead, which results in a longer loading time. The `dvisvgm` backend is only used if explicitly set by the user. An open point of discussion is whether `Poppler_jll` should have precedence over `dvisvgm`in this sense.

```julia
using TikzPictures # loads a default backend

# set any of the backends explicitly
svgBackend(PdfToSvgBackend()) # default if pdf2svg is installed
svgBackend(PopplerBackend()) # default otherwise
svgBackend(DVIBackend()) # only used if set explicitly this way
```

## Loading times

`pdf2svg` is already installed on my local machine, so loading `TikzPictures.jl` will be fast there. I can set the backend to poppler manually, afterwards, to see what loading `Poppler_jll` does. I tried this with julia v1.3 and v1.5, the last of which has improved loading `*_jll` packages a lot.

command | v1.3 | v1.5
--- | --- | ---
`@time using TikzPictures` | 0.4 seconds | 0.3 seconds
`@time svgBackend(PopplerBackend())` | > 9 seconds | 3.9 seconds

## Testing

Travis CI is testing PR currently on julia v1.0 (yes, it works again), v1.3, and v1.5. The only platform, however, is Linux. `Poppler_jll` should work everywhere, but I have not yet figured out how to tell Travis to install texlive etc on Mac OS and Windows. Any improvement of the `.travis.yml` in this direction is warmly welcome!
