### PR TITLE
Added custom environments to support tikz-cd

### DIFF
--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -12,8 +12,9 @@ mutable struct TikzPicture
     data::AbstractString
     options::AbstractString
     preamble::AbstractString
+    environment::AbstractString
     enableWrite18::Bool
-    TikzPicture(data::AbstractString; options="", preamble="", enableWrite18=true) = new(data, options, preamble, enableWrite18)
+    TikzPicture(data::AbstractString; options="", preamble="", environment="tikzpicture", enableWrite18=true) = new(data, options, preamble, environment, enableWrite18)
 end
 
 mutable struct TikzDocument
@@ -125,13 +126,13 @@ function save(f::Union{TEX,TIKZ}, tp::TikzPicture)
             println(tex, tp.preamble)
             println(tex, "\\begin{document}")
         end
-        print(tex, "\\begin{tikzpicture}[")
+        print(tex, "\\begin{$(tp.environment)}[")
         print(tex, tp.options)
         println(tex, "]")
     end
     println(tex, tp.data)
     if f.limit_to in [:all, :picture]
-        println(tex, "\\end{tikzpicture}")
+        println(tex, "\\end{$(tp.environment)}")
         if f.limit_to == :all
             println(tex, "\\end{document}")
         end
@@ -159,11 +160,11 @@ function save(f::TEX, td::TikzDocument)
     i = 1
     for tp in td.pictures
         println(tex, "\\centering")
-        print(tex, "\\begin{tikzpicture}[")
+        print(tex, "\\begin{$(tp.environment)}[")
         print(tex, tp.options)
         println(tex, "]")
         println(tex, tp.data)
-        println(tex, "\\end{tikzpicture}")
+        println(tex, "\\end{$(tp.environment)}")
         print(tex, "\\captionof{figure}{")
         print(tex, td.captions[i])
         println(tex, "}")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,7 +81,7 @@ end
 
 # Test tikz-cd
 
-data = "A\\arrow[rd]\\arrow[r] & B \\\\& C"
+data = "A\\arrow{rd}\\arrow{r} & B \\\\& C"
 tp = TikzPicture(data, options="scale=0.25", environment="tikzcd", preamble="\\usepackage{tikz-cd}")
 td = TikzDocument()
 push!(td, tp, caption="hello")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,7 +81,7 @@ end
 
 # Test tikz-cd
 
-data = "A\\arrow[rd]\\arrow[r, \"\\phi\"] & B \\\\& C"
+data = "A\\arrow[rd]\\arrow[r] & B \\\\& C"
 tp = TikzPicture(data, options="scale=0.25", environment="tikzcd", preamble="\\usepackage{tikz-cd}")
 td = TikzDocument()
 push!(td, tp, caption="hello")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,9 @@ end
 
 # Pre-test cleanup (for repeated tests)
 for file in ["testPic.pdf", "testPic.svg", "testDoc.pdf", "testDoc.tex", first.(svgBackends)...]
-	if isfile(file)
-		rm(file)
-	end
+  if isfile(file)
+    rm(file)
+  end
 end
 
 # Run tests
@@ -39,6 +39,7 @@ function has_environment(content::String, environment::String)
         error("\\begin{$environment} and \\end{$environment} do not match")
     end
 end
+
 filecontent = join(readlines("testPic.tex", keep=true)) # read with line breaks
 @test occursin(data, filecontent) # also check that the data is contained
 @test has_environment(filecontent, "tikzpicture")
@@ -60,8 +61,8 @@ filecontent = join(readlines("testPic.tex", keep=true))
 
 save(TEX("testPic"), tp) # save again with limit_to=:all
 if success(`lualatex -v`)
-	save(PDF("testPic"), tp)
-	@test isfile("testPic.pdf")
+  save(PDF("testPic"), tp)
+  @test isfile("testPic.pdf")
 
     save(SVG("testPic"), tp)
     @test isfile("testPic.svg") # default SVG backend
@@ -74,6 +75,31 @@ if success(`lualatex -v`)
 
     save(PDF("testDoc"), td)
     @test isfile("testDoc.pdf")
+else
+    @warn "lualatex is missing; can not test compilation"
+end
+
+# Test tikz-cd
+
+data = "A\\arrow[rd]\\arrow[r, \"\\phi\"] & B \\\\& C"
+tp = TikzPicture(data, options="scale=0.25", environment="tikzcd", preamble="\\usepackage{tikz-cd}")
+td = TikzDocument()
+push!(td, tp, caption="hello")
+
+save(TEX("testCD"), tp)
+@test isfile("testCD.tex")
+
+filecontent = join(readlines("testCD.tex", keep=true)) # read with line breaks
+@test occursin(data, filecontent) # also check that the data is contained
+@test has_environment(filecontent, "tikzcd")
+@test has_environment(filecontent, "document")
+
+if success(`lualatex -v`)
+    save(PDF("testCD"), tp)
+    @test isfile("testCD.pdf")
+
+    save(PDF("testCDDoc"), td)
+    @test isfile("testCDDoc.pdf")
 else
     @warn "lualatex is missing; can not test compilation"
 end


### PR DESCRIPTION
Takes a stab at #58. Currently all I have done is added a new field in the `TikzPicture` struct for the environment where the default is `tikzpicture` so that it doesn't break any past TikzPictures.jl code. I also added a couple tests to verify that the environment is working correctly and that it successfully outputs a pdf of a TikzPicture and a TikzDocument that uses tikz-cd. Didn't add too many tests for this to not have too much duplicate code, I think there could be a new function here to generate tests for both a `tikzpicture` and a `tikzcd` example.

Heres a working example using the new code:

```
julia> using TikzPictures
julia> tp = TikzPicture("A\\arrow[rd]\\arrow[r, \"\\phi\"] & B \\\\& C", environment="tikzcd", preamble="\\usepackage{tikz-cd}")
julia> save(SVG("test"), tp)
```