### PR TITLE
Trying to fix the tests at RegistryCI

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -54,12 +54,14 @@ end
 # backend initialization
 _initialize(backend::SVGBackend) = nothing # default
 _initialize(backend::PopplerBackend) =
-    try
+    if !Requires.isprecompiling()
         @eval Main begin
-            import Poppler_jll # will trigger @require in __init__svg
+            try
+                import Poppler_jll # will trigger @require in __init__svg
+            catch
+                error("Unable to initialize $backend") # should not happen as long as Poppler_jll is a dependency
+            end
         end
-    catch
-        error("Unable to initialize $backend") # should not happen as long as Poppler_jll is a dependency
     end
 
 # compile a temporary PDF file that can be converted to SVG

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -23,7 +23,12 @@ function __init__svg()
     if Sys.which("pdf2svg") != nothing
         svgBackend(PdfToSvgBackend())
     else
-        svgBackend(PopplerBackend())
+        try
+            svgBackend(PopplerBackend())
+        catch cause
+            @warn "Failed to load PopplerBackend; falling back on DVIBackend" cause
+            svgBackend(DVIBackend())
+        end
     end
 
     # define a new implementation for PopplerBackend, but only after `import Poppler_jll`
@@ -55,11 +60,11 @@ end
 _initialize(backend::SVGBackend) = nothing # default
 _initialize(backend::PopplerBackend) =
     if !Requires.isprecompiling()
-        @eval Main begin
+        @eval TikzPictures begin
             try
                 import Poppler_jll # will trigger @require in __init__svg
             catch
-                error("Unable to initialize $backend") # should not happen as long as Poppler_jll is a dependency
+                error("Unable to import Poppler_jll") # should not happen as long as Poppler_jll is a dependency
             end
         end
     end


### PR DESCRIPTION
The `@eval` statement, which dynamically loads the Poppler_jll backend, now evaluates in the scope of TikzPictures instead of the Main scope. Moreover, if anything breaks while setting the default backend, there is a fallback to the DVI backend.

The discussion around this issue has so far been going on here: https://github.com/JuliaRegistries/General/pull/20417

It might be worth a try to trigger the release again and see if it works with the cautions taken in this PR.