### PR TITLE
Make limit_to available for TIKZ like with TEX

### DIFF
--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -101,7 +101,7 @@ end
 mutable struct TIKZ <: SaveType
     filename::AbstractString
     limit_to::Symbol
-    TIKZ(filename::AbstractString) = new(removeExtension(filename, ".tikz"), :all)
+    TIKZ(filename::AbstractString; include_preamble::Bool=true, limit_to::Symbol=(include_preamble ? :all : :picture)) = new(removeExtension(filename, ".tikz"), limit_to)
 end
 
 mutable struct SVG <: SaveType


### PR DESCRIPTION
This exposes limit_to in the constructor of TIKZ just like TEX does,
including the option include_preamble to keep things consistent.