### PR TITLE
Remove undefined macro L_mstr

### DIFF
--- a/src/TikzPictures.jl
+++ b/src/TikzPictures.jl
@@ -2,8 +2,8 @@ module TikzPictures
 
 export TikzPicture, PDF, TEX, TIKZ, SVG, save, tikzDeleteIntermediate, tikzCommand, TikzDocument, push!
 import Base: push!
-import LaTeXStrings: LaTeXString, @L_str, @L_mstr
-export LaTeXString, @L_str, @L_mstr
+import LaTeXStrings: LaTeXString, @L_str
+export LaTeXString, @L_str
 
 _tikzDeleteIntermediate = true
 _tikzCommand = "lualatex"


### PR DESCRIPTION
`@L_mstr` is not defined anymore in LaTeXStrings.jl. This commit removes importing the undefined macro.

Refer to: https://github.com/stevengj/LaTeXStrings.jl/issues/42