### PR TITLE
Add Tectonic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "3.3.3"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Tectonic = "9ac5f52a-99c6-489f-af81-462ef484790f"
 
 [compat]
-julia = "1"
 LaTeXStrings = "1.1"
 Poppler_jll = "0.87"
 Requires = "1.0"
+Tectonic = "0.5"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/testPic.tex
+++ b/test/testPic.tex
@@ -1,0 +1,10 @@
+\documentclass[tikz]{standalone}
+
+\begin{document}
+\begin{tikzpicture}[scale=0.25]
+\draw (0,0) -- (10,10);
+\draw (10,0) -- (0,10);
+\node at (5,5) {tikz $\sqrt{\pi}$};
+\end{tikzpicture}
+
+\end{document}


### PR DESCRIPTION
In response to https://github.com/JuliaTeX/TikzPictures.jl/issues/75.

> Let's have it as the default if lualatex -v fails, and make it switchable as well 

Unfortunately, it's gonna take me quite a lot of time to figure out the logic to make Tectonic as an optional back end. I would personally not bother with supporting so many backends and focus on one good one, but that might be my naivety. I have no idea who uses this package.

In this draft PR, I've added Tectonic and confirmed that it works with
```
tp = TikzPicture("\\draw (0,0) -- (10,10);\n\\draw (10,0) -- (0,10);\n\\node at (5,5) {tikz \$\\sqrt{\\pi}\$};", options="scale=0.25", preamble="")
save(PDF("test"), tp)
```
Note that Tectonic doesn't support the `--enableWrite18` flag, so that is why I disabled it in the code.

Maybe, you could decide whether this Tectonic addition is still the way to go forward and pick up this PR?