### PR TITLE
Updates to work on apple silicon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"  # earliest version supported
+          - "1.6"  # earliest version supported
           - "1"    # Latest Release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LaTeXStrings = "1.1"
 Poppler_jll = "21.9"
 Requires = "1.1"
 tectonic_jll = "0.13"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,13 +7,13 @@ version = "3.4.2"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 Poppler_jll = "9c32591e-4766-534b-9725-b71a8799265b"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Tectonic = "9ac5f52a-99c6-489f-af81-462ef484790f"
+tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
 
 [compat]
 LaTeXStrings = "1.1"
 Poppler_jll = "0.87"
 Requires = "1.1"
-Tectonic = "0.8"
+tectonic_jll = "0.13"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TikzPictures"
 uuid = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
 license = "MIT"
-version = "3.4.2"
+version = "3.5.0"
 
 [deps]
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ tectonic_jll = "d7dd28d6-a5e6-559c-9131-7eb760cdacc5"
 
 [compat]
 LaTeXStrings = "1.1"
-Poppler_jll = "0.87"
+Poppler_jll = "21.9"
 Requires = "1.1"
 tectonic_jll = "0.13"
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 This library allows one to create Tikz pictures and save in various formats. It integrates with IJulia, outputting SVG images to the notebook.
 
-This library will try to use the lualatex package already installed on the system. Lualatex may be installed through the texlive and miktex distributions. You should have dvisvgm installed. On Ubuntu, you can get these, if not already present, by running `sudo apt-get install texlive-latex-base` and `sudo apt-get install texlive-binaries`. If the library cannot run lualatex, it will fall back to trying to use tectonic for the compilation.
+This library will try to use the lualatex package already installed on the system. If the library cannot run lualatex, it will fall back to trying to use tectonic for the compilation. 
+
+Lualatex may be installed through the texlive and miktex distributions. You should have dvisvgm installed. On Ubuntu, you can get the required packages, if not already present, by running `sudo apt-get install pdf2svg texlive-latex-base texlive-binaries texlive-pictures texlive-latex-extra texlive-luatex`.
 
 Note: this package will attempt to turn off interpolation in the generated SVG, but this currently only works in Chrome.
 


### PR DESCRIPTION
- Switched from Tectonic.jl to tectonic_jll (https://github.com/JuliaTeX/TikzPictures.jl/issues/82)
- Updated version for Poppler_jll to an apple silicon supported version (https://github.com/JuliaTeX/TikzPictures.jl/issues/82)
- Added `bool_success` to return a boolean versus the default exception when lualatex wasn't installed (was originally using `Base.success`) (https://github.com/JuliaTeX/TikzPictures.jl/issues/83)
- Updated readme to help with texlive installation (https://github.com/JuliaTeX/TikzPictures.jl/issues/68)
- Bumped version 